### PR TITLE
Update Drupal 8 quickstart

### DIFF
--- a/docs/radix-4.md
+++ b/docs/radix-4.md
@@ -9,12 +9,13 @@ Documentation for Radix 4.x theme for Drupal 8.
 
 ## Quick start for Drupal 8
 
-1. Download and enable radix: `drush dl radix; drush en radix -y;`.
-2. Create a subtheme: `drush radix "SUBTHEME NAME"`.
-3. Set default theme: `drush en SUBTHEME_NAME -y; drush config-set system.theme default SUBTHEME_NAME -y`.
-4. Install required modules: `cd /path/to/SUBTHEME_NAME; npm install;`.
-5. Update proxy in `/path/to/SUBTHEME_NAME/webpack.mix.js`.
-6. Watch: `npm run watch`.
+1. Download and enable Components module: `drush dl components && drush en components -y`.
+2. Download and enable Radix: `drush dl radix && drush en radix -y`.
+3. Create a subtheme: `drush radix "SUBTHEME NAME"`.
+4. Set default theme: `drush en SUBTHEME_NAME -y && drush config-set system.theme default SUBTHEME_NAME -y`.
+5. Install required modules: `cd /path/to/SUBTHEME_NAME && npm install`.
+6. Update proxy in `/path/to/SUBTHEME_NAME/webpack.mix.js`.
+7. Watch: `npm run watch`.
 
 ## Using Composer
 Use the following command to install Radix using composer. This will pull in Radix and the Components module.


### PR DESCRIPTION
Hello,

I was following the docs to create a Radix subtheme, but I noticed these were missing the step concerning the Components module. So this pull requests aligns the docs with the quickstart instructions as available on the drupal.org project page.